### PR TITLE
Export GetServerSideContext/GetStaticPathsContext as interface not type alias

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -111,7 +111,7 @@ export type InferGetStaticPropsType<T> = T extends GetStaticProps<infer P, any>
   ? P
   : never
 
-export type GetStaticPathsContext = {
+export interface GetStaticPathsContext {
   locales?: string[]
   defaultLocale?: string
 }
@@ -125,9 +125,9 @@ export type GetStaticPaths<P extends ParsedUrlQuery = ParsedUrlQuery> = (
   context: GetStaticPathsContext
 ) => Promise<GetStaticPathsResult<P>>
 
-export type GetServerSidePropsContext<
+export interface GetServerSidePropsContext<
   Q extends ParsedUrlQuery = ParsedUrlQuery
-> = {
+> {
   req: IncomingMessage
   res: ServerResponse
   params?: Q


### PR DESCRIPTION
Declaration merging is not available for type alias.
Exporting them as interface enables third party library like next-redux-wrapper to extend context.

(next-redux-wrapper already extends context for getInitialProps.)
https://github.com/kirill-konshin/next-redux-wrapper/blob/4ae9162b9e8921367ea95aae7f8db2c65786fa03/packages/wrapper/src/index.tsx#L268